### PR TITLE
dada_dadaReads.runpool.R fix

### DIFF
--- a/workflow/scripts/dada_dadaReads.runpool.R
+++ b/workflow/scripts/dada_dadaReads.runpool.R
@@ -56,7 +56,7 @@ if(as.logical(snakemake@config[['dada']][['no_error_assumptions']])){
   err <- readRDS(errfile)
 }
 
-# Sample inference and merger of paired-end reads
+# Sample inference
 derep <- derepFastq(filt)
 if("list" %in% class(derep)){
   derep <- lapply(derep, function(x){

--- a/workflow/scripts/dada_dadaReads.runpool.R
+++ b/workflow/scripts/dada_dadaReads.runpool.R
@@ -24,7 +24,7 @@ library(Biostrings)
 errfile <- snakemake@input[[1]]
 
 filt <- unlist(snakemake@input[-1])
-sizes <- sapply(filt,function(x) file.info(x)$size)
+sizes <- sapply(filt, function(x){ as.numeric(system2("zcat",args=c(x," 2>/dev/null | head | wc -l"), stdout=T)) })
 filt <- filt[sizes>0]
 
 filtNames <- sapply(filt,

--- a/workflow/scripts/dada_dadaReads.runpool.R
+++ b/workflow/scripts/dada_dadaReads.runpool.R
@@ -58,7 +58,15 @@ if(as.logical(snakemake@config[['dada']][['no_error_assumptions']])){
 
 # Sample inference and merger of paired-end reads
 derep <- derepFastq(filt)
-if(any(derep$quals[!is.na(derep$quals)]<0)) derep$quals <- derep$quals+33
+if("list" %in% class(derep)){
+  derep <- lapply(derep, function(x){
+    if(any(x$quals[!is.na(x$quals)]<0)){ x$quals <- x$quals+33 }
+    return(x)
+  })
+} else {
+  if(any(derep$quals[!is.na(derep$quals)]<0)) derep$quals <- derep$quals+33
+}
+
 if(snakemake@params[['pooling']]=="pseudo"){
   print(paste0("make pseudo-pooled dada object"))
   dada <- dada(derep, err=err, multithread=snakemake@threads,


### PR DESCRIPTION
Hello Anna!

This PR will fix an error
```
Error in rep(seq(length(uniques)), tab[tab > 0]) : 
  invalid 'times' argument
```
which appears when input file is empty (but .gz file has a non-zero size, e.g. 20 bytes) - see for example [S253.fastq.gz](https://github.com/a-h-b/dadasnake/files/5615559/S253.fastq.gz) (one of the samples failed and this file appeared after quality filtering with dadasnake).
We do not need to count all lines in input files (they could be quite large), therefore I use `head` - this is just a slightly modified trick I've seen in your code [here](https://github.com/a-h-b/dadasnake/blob/a42ace302c1b46b6400d69ea77971abe41242f73/workflow/scripts/dada_dadaReads.single.R#L48).

And if there are multiple input files in `filt`, the result of `derepFastq` would be a list and [this line](https://github.com/a-h-b/dadasnake/blob/a42ace302c1b46b6400d69ea77971abe41242f73/workflow/scripts/dada_dadaReads.runpool.R#L61) will be ignored. So we should modify `quals` in each slot of the list.

Probably the other scripts are affected as well (e.g., `dada_dadaReads.runpool.noError.R`, `dada_dadaReads.pool.R`). But I haven't touched them because I don't want to break something.

With kind regards,
Vladimir